### PR TITLE
Fix Fillable.java

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,27 @@ The release comes with a pre-packaged jar file named `gs-ui-swing.jar` that cont
 - [gs-core](https://github.com/graphstream/gs-core/releases)
 - [gs-ui-swing](https://github.com/graphstream/gs-ui-swing/releases)
 
-Maven users, you may include `gs-core` and `gs-ui-swing` as a dependency to your project using <https://jitpack.io>.
-Simply add the `jitpack` repository to the `pom.xml`:
+Maven users may include major releases of `gs-core` and `gs-ui-swing` as dependencies: 
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.graphstream</groupId>
+        <artifactId>gs-core</artifactId>
+        <version>2.0</version>
+    </dependency>
+
+    <dependency>
+        <groupId>org.graphstream</groupId>
+        <artifactId>gs-ui-swing</artifactId>
+        <version>2.0</version>
+    </dependency>
+</dependencies>
+```
+
+### Development Versions
+
+Using <https://jitpack.io> one can also use any development version. Simply add the `jitpack` repository to the `pom.xml` of the project:
 
 ```xml
 <repositories>
@@ -40,23 +59,25 @@ Simply add the `jitpack` repository to the `pom.xml`:
 then, add the `gs-core` and `gs-ui-swing` to your dependencies:
 
 ```xml
-<dependency>
-    <groupId>com.github.graphstream</groupId>
-    <artifactId>gs-core</artifactId>
-    <version>2.0</version>
-</dependency>
-<dependency>
-    <groupId>com.github.graphstream</groupId>
-    <artifactId>gs-ui-swing</artifactId>
-    <version>2.0</version>
-</dependency>
+<dependencies>
+    <dependency>
+        <groupId>com.github.graphstream</groupId>
+        <artifactId>gs-core</artifactId>
+        <version>2.0</version>
+    </dependency>
+    <dependency>
+        <groupId>com.github.graphstream</groupId>
+        <artifactId>gs-ui-swing</artifactId>
+        <version>2.0</version>
+    </dependency>
+</dependencies>
 ```
 
 You can use any version of `gs-core` and `gs-ui-swing` you need, provided they are the same. Simply specify the desired version in the `<version>` tag. The version can be a git tag name (e.g. `2.0`), a commit number, or a branch name followed by `-SNAPSHOT` (e.g. `dev-SNAPSHOT`). More details on the [possible versions on jitpack](https://jitpack.io/#graphstream/gs-core).
 
 ## Configure UI
 
-Finally, `gs-core` needs to be told which UI implementation to use. Simply add a system property to you project: 
+Finally, `gs-core` needs to be told which UI implementation to use. Simply add a system property to you project:
 
 ```java
 System.setProperty("org.graphstream.ui", "swing");
@@ -69,14 +90,16 @@ java -Dorg.graphstream.ui=swing YourClass
 ```
 
 ## Camera and Visualization
-Graphstream spring has camera movement build in. 
-Besides beeing able to move elements around with the mouse following keys have a feature:
+
+GraphStream spring has camera movement build in. Besides being able to move elements around with the mouse following keys have a feature:
+
 * left/right/up/down: Move the camera in that direction.
 * page start: Zoom in
 * page end: Zoom out
-* SHIFT + r: Reset cameraview.
+* SHIFT + r: Reset camera view.
 
 Further information about usage can be found in our [Graph-Visualisation](http://graphstream-project.org/doc/Tutorials/Graph-Visualisation/) tutorial.
+
 ## Help
 
 You may check the documentation on the [website](http://graphstream-project.org). You may also share your questions on the mailing list at http://sympa.litislab.fr/sympa/subscribe/graphstream-users

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ then, add the `gs-core` and `gs-ui-swing` to your dependencies:
 <dependency>
     <groupId>com.github.graphstream</groupId>
     <artifactId>gs-core</artifactId>
-    <version>dev-SNAPSHOT</version>
+    <version>2.0</version>
 </dependency>
 <dependency>
     <groupId>com.github.graphstream</groupId>
     <artifactId>gs-ui-swing</artifactId>
-    <version>dev-SNAPSHOT</version>
+    <version>2.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,8 @@
 	<groupId>org.graphstream</groupId>
 	<artifactId>gs-ui-swing</artifactId>
 	<version>2.0</version>
-	
+	<packaging>jar</packaging>
+
 	<name>gs-ui-swing</name>
 	<description>Swing interface for GraphStream</description>
   
@@ -45,6 +46,23 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	
+	<developers>
+		<developer>
+			<id>hbrahimi</id>
+			<name>Hicham Brahimi</name>
+			<email>hicham.brahimi@graphstream-project.org</email>
+			<organization>LITIS</organization>
+			<organizationUrl>http://www.litislab.eu</organizationUrl>
+		</developer>
+		<developer>
+			<id>ypigne</id>
+			<name>Yoann Pigné</name>
+			<email>yoann.pigne@graphstream-project.org</email>
+			<organization>LITIS</organization>
+			<organizationUrl>http://www.litislab.eu</organizationUrl>
+		</developer>
+	</developers>
+
 	<licenses>
 		<license>
 			<name>LGPL3</name>
@@ -53,8 +71,7 @@
 
 		<license>
 			<name>Cecill-C</name>
-			<url>http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html
-			</url>
+			<url>http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html</url>
 		</license>
 	</licenses>
 	
@@ -65,6 +82,12 @@
 				enable the sign phase.
 			-->
 			<id>release</id>
+			<distributionManagement>
+				<repository>
+					<id>ossrh</id>
+					<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+				</repository>
+			</distributionManagement>
 			<build>
 				<plugins>
 					<plugin>
@@ -243,17 +266,10 @@
 			</plugin>
 		</plugins>
 	</reporting>
-
-	<repositories>
-		<repository>
-		    <id>jitpack.io</id>
-			<url>https://jitpack.io</url>
-		</repository>
-	</repositories>
 	
 	<dependencies>
 		<dependency>
-    		<groupId>com.github.graphstream</groupId>
+    		<groupId>org.graphstream</groupId>
     		<artifactId>gs-core</artifactId>
     		<version>2.0</version>
 			<scope>provided</scope>
@@ -268,7 +284,7 @@
 		</dependency>
 		
 		<dependency>
-    		<groupId>com.github.graphstream</groupId>
+    		<groupId>org.graphstream</groupId>
     		<artifactId>gs-algo</artifactId>
     		<version>2.0</version>
     		<scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	
 	<groupId>org.graphstream</groupId>
 	<artifactId>gs-ui-swing</artifactId>
-	<version>2.1-SNAPSHOT</version>
+	<version>2.0</version>
 	
 	<name>gs-ui-swing</name>
 	<description>Swing interface for GraphStream</description>
@@ -255,7 +255,7 @@
 		<dependency>
     		<groupId>com.github.graphstream</groupId>
     		<artifactId>gs-core</artifactId>
-    		<version>dev-SNAPSHOT</version>
+    		<version>2.0</version>
 			<scope>provided</scope>
 		</dependency>
 		
@@ -270,7 +270,7 @@
 		<dependency>
     		<groupId>com.github.graphstream</groupId>
     		<artifactId>gs-algo</artifactId>
-    		<version>dev-SNAPSHOT</version>
+    		<version>2.0</version>
     		<scope>test</scope>
     	</dependency>
 

--- a/src/org/graphstream/ui/swing/renderer/shape/swing/shapePart/Fillable.java
+++ b/src/org/graphstream/ui/swing/renderer/shape/swing/shapePart/Fillable.java
@@ -103,7 +103,7 @@ public class Fillable {
   	public void configureFillableForElement( Style style, DefaultCamera2D camera, GraphicElement element ) {
   	  	if( style.getFillMode() == StyleConstants.FillMode.DYN_PLAIN && element != null ) {
   	  		if ( element.getAttribute( "ui.color" ) instanceof Number ) {
-  	  			theFillPercent = (float)((Number)element.getAttribute( "ui.color" ));
+  	  			theFillPercent = ((Number)element.getAttribute( "ui.color" )).floatValue();
   	  			theFillColor = null;
   	  		}
   	  		else if ( element.getAttribute( "ui.color" ) instanceof Color ) {


### PR DESCRIPTION
When I started demo from gs-algo/src-test/org/graphstream/algorithm/measure/demo/*
I got that Exception:
Exception in thread "AWT-EventQueue-0" java.lang.ClassCastException: class java.lang.Double cannot be cast to class java.lang.Float (java.lang.Double and java.lang.Float are in module java.base of loader 'bootstrap')
	at org.graphstream.ui.swing.renderer.shape.swing.shapePart.Fillable.configureFillableForElement(Fillable.java:106)