### PR TITLE
Fix Fillable.java

### DIFF
--- a/src/org/graphstream/ui/swing/renderer/shape/swing/shapePart/Fillable.java
+++ b/src/org/graphstream/ui/swing/renderer/shape/swing/shapePart/Fillable.java
@@ -103,7 +103,7 @@ public class Fillable {
   	public void configureFillableForElement( Style style, DefaultCamera2D camera, GraphicElement element ) {
   	  	if( style.getFillMode() == StyleConstants.FillMode.DYN_PLAIN && element != null ) {
   	  		if ( element.getAttribute( "ui.color" ) instanceof Number ) {
-  	  			theFillPercent = (float)((Number)element.getAttribute( "ui.color" ));
+  	  			theFillPercent = ((Number)element.getAttribute( "ui.color" )).floatValue();
   	  			theFillColor = null;
   	  		}
   	  		else if ( element.getAttribute( "ui.color" ) instanceof Color ) {


### PR DESCRIPTION
When I started demo from gs-algo/src-test/org/graphstream/algorithm/measure/demo/*
I got that Exception:
Exception in thread "AWT-EventQueue-0" java.lang.ClassCastException: class java.lang.Double cannot be cast to class java.lang.Float (java.lang.Double and java.lang.Float are in module java.base of loader 'bootstrap')
	at org.graphstream.ui.swing.renderer.shape.swing.shapePart.Fillable.configureFillableForElement(Fillable.java:106)